### PR TITLE
#1 Fix adding linear regression line for animation

### DIFF
--- a/curvePlot_VideoPrep_fitPlot.py
+++ b/curvePlot_VideoPrep_fitPlot.py
@@ -68,7 +68,7 @@ with writer.saving(fig, "fitPlot.mp4", 100):
         writer.grab_frame()
 
     # Add the line fit
-    for xval,yval in zip(xline,xline):
+    for xval,yval in zip(xline,yline):
 
         xLineList.append(xval)
         yLineList.append(yval)


### PR DESCRIPTION
**Related issue:** #1

**Before:**
![fitPlot_incorrect](https://github.com/codinglikemad/pyAnimTutorial/assets/67978573/34756df2-4c46-4821-be69-e912c2c961df)

**After:**
![fitPlot_correct](https://github.com/codinglikemad/pyAnimTutorial/assets/67978573/e698dba8-cc5f-4d83-a775-7667f75d2399)
